### PR TITLE
Meldekort trenger ikke nivå 4 for pålogging

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -44,7 +44,7 @@ spec:
     sidecar:
       enabled: true
       autoLogin: true
-      level: Level4
+      level: idporten-loa-substantial
   ingresses:
   {{#each ingresses as |url|}}
     - {{url}}


### PR DESCRIPTION
nav.no sier man kan sende meldekort med Min ID, som er på nivå 3. Etter en gjennomgang med sikkerhetsseksjonen så vi at meldekort kan senkes fra nivå 4 til nivå 3.